### PR TITLE
Adds contribution notes that github will use as a banner on new issues.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+### Before you open an issue
+
+**Has it already been reported?**  
+Check the [issue tracker](https://github.com/KospY/KAS/issues) and the [Known issues](https://github.com/KospY/KAS/wiki/Known%20issues) to see if the problem has already been reported. If it has, please add any additional information you have instead of opening a new issue. If you're unsure if your issue is related, comment on the existing report first.
+
+**Is it intended behavior? / Are you doing it right?**  
+Make sure you're encountering a bug and not just an intended aspect of the mod. For exemple, if a winch isn't working, make sure you have enough electrical power. 
+
+**Is it actually a KAS problem?**  
+See if the problem occurs if you uninstall KAS, and also see if it occurs when KAS is the *only* mod installed. For now, no conflicts has been reported between KAS and another mod, but it's always better to check if it's not the case.
+
+**Are you up-to-date?**  
+Only the latest version of KAS and the latest version of KSP are supported. Make sure both are completely up-to-date before filing a report.
+
+### Opening an issue
+
+Bug reports and feature requests should be filled on the [issue tracker](https://github.com/KospY/KAS/issues). Please read the following guidelines for filing reports; it's very difficult for me to help otherwise.
+
+1. **Be specific.** The title and description of your report should describe exactly what isn't working. Provide reproduction steps if you can, and explain in detail the symptoms of the issue and what causes it.
+2. **Provide your output log.** This file can be found at `KSP/KSP_Data/output_log.txt`. This contains debug information about your last KSP session. Without this, I cannot diagnose most issues. If your report has precise reproduction steps and the cause is obvious, the log is optional. When in doubt, please include it.
+3. **List other mods.** While mod compatibility issues are rare, you should list all the other mods you have installed.
+4. **System specifications.** Include your hardware specifications (CPU, GPU, RAM) and your operating system. Also include whether you're using Steam or the manual download of KSP and the folder where KSP is installed.
+5. **One issue per report.** If you have multiple issues, submit multiple reports. Don't lump everything together; it becomes difficult to track disparate issues that way.
+
+If you don't have enough information to file a bug report, you may ask questions on the forum thread. **Do not send me private messages about bugs unless you believe the bug is an exploitable security issue.**


### PR DESCRIPTION
I desperately want to close some of the issues that've been opened without reading the [Bug Reporting Guidelines](https://github.com/KospY/KAS/wiki/Bug%20Reporting) article. But I can't do that, and so this is the best I can do to help.

This simply duplicates the contents on the wiki in a file that will add a yellow banner at the top of the form when a new issue is being created -- [here's an example](https://github.com/angular/angular.js/issues/new). If you merge this I'll update the wiki to point to this new file so you don't have to maintain both documents.

It's not the best phrasing, but it may help get people to click it and read it.. maybe? Anyway, thanks for the awesome mod. I look forward to the 1.0 support release. =)