### PR TITLE
Updated compat check to look for 1.0.2

### DIFF
--- a/Plugin/CompatibilityChecker.cs
+++ b/Plugin/CompatibilityChecker.cs
@@ -54,7 +54,7 @@ namespace KAS
 
             const int compatibleMajor = 1;
             const int compatibleMinor = 0;
-            const int compatibleRevision = 1;
+            const int compatibleRevision = 2;
 
             return (Versioning.version_major == compatibleMajor) && (Versioning.version_minor == compatibleMinor) && (Versioning.Revision == compatibleRevision);
 

--- a/Plugin/CompatibilityChecker.cs
+++ b/Plugin/CompatibilityChecker.cs
@@ -52,9 +52,9 @@ namespace KAS
             |    BEGIN IMPLEMENTATION-SPECIFIC EDITS HERE.    |
             \*-----------------------------------------------*/
 
-            const int compatibleMajor = 0;
-            const int compatibleMinor = 90;
-            const int compatibleRevision = 0;
+            const int compatibleMajor = 1;
+            const int compatibleMinor = 0;
+            const int compatibleRevision = 1;
 
             return (Versioning.version_major == compatibleMajor) && (Versioning.version_minor == compatibleMinor) && (Versioning.Revision == compatibleRevision);
 


### PR DESCRIPTION
I realize this is trivial, but I'm really wanting to use KAS with the new resources system. I have not extensively tested all functionality yet, but the wench works fine. This pull request simply updates the version check to 1.0.2.