### PR TITLE
Ksp 1.0.2 support

### DIFF
--- a/Plugin/CompatibilityChecker.cs
+++ b/Plugin/CompatibilityChecker.cs
@@ -52,9 +52,9 @@ namespace KAS
             |    BEGIN IMPLEMENTATION-SPECIFIC EDITS HERE.    |
             \*-----------------------------------------------*/
 
-            const int compatibleMajor = 0;
-            const int compatibleMinor = 90;
-            const int compatibleRevision = 0;
+            const int compatibleMajor = 1;
+            const int compatibleMinor = 0;
+            const int compatibleRevision = 2;
 
             return (Versioning.version_major == compatibleMajor) && (Versioning.version_minor == compatibleMinor) && (Versioning.Revision == compatibleRevision);
 

--- a/Plugin/KAS.csproj
+++ b/Plugin/KAS.csproj
@@ -11,12 +11,14 @@
     <AssemblyName>KAS</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>bin/Debug/</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -24,19 +26,19 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>bin/Release/</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\Games\KSP\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>../../../Games/KSP/KSP_Data/Managed/Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\Games\KSP\KSP_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>../../../Games/KSP/KSP_Data/Managed/UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -62,7 +64,7 @@
     <Compile Include="KASModuleGrab.cs" />
     <Compile Include="KASModulePartBay.cs" />
     <Compile Include="KAS_Shared.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties/AssemblyInfo.cs" />
     <Compile Include="KASModuleTimedBomb.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Plugin/Properties/AssemblyInfo.cs
+++ b/Plugin/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("0.4.7")]
+[assembly: AssemblyInformationalVersion("0.4.11")]


### PR DESCRIPTION
This just removes the compatibility warning from KAS.

Additionally I changed the path delimiters to support Linux. This should still work in Windows.