### PR TITLE
Updated link in README.md to point to the current forum page for KAS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ It gives some purpose to EVA and can be used for many things:
 
 
 ===
-Forum thread: [KAS](http://forum.kerbalspaceprogram.com/showthread.php/25563-0-20-KAS-v0-3-1-Kerbal-Attachment-System)  
+Forum thread: [KAS](http://forum.kerbalspaceprogram.com/threads/92514-1-0-2-Kerbal-Attachment-System-%28KAS%29-0-5-0) 


### PR DESCRIPTION
The current link in README.md points to the old forum thread for KAS.  I've changed this to point to the current thread.