### PR TITLE
Cleans up the .version file.

### DIFF
--- a/kas.version
+++ b/kas.version
@@ -1,25 +1,24 @@
 {
-	"NAME":"KAS",
-	"URL":"https://raw.githubusercontent.com/KospY/KAS/master/kas.version",
-	"DOWNLOAD":"http://forum.kerbalspaceprogram.com/threads/92514-0-24-2-Kerbal-Attachment-System-%28KAS%29-0-4-8-Fixed-for-0-24-2-x86-x64-%29",
-	"CHANGE_LOG_URL":"https://raw.githubusercontent.com/KospY/KAS/master/changelog.md",
-	"GITHUB":
+    "NAME": "Kerbal Attachment System",
+    "URL": "https://raw.githubusercontent.com/KospY/KAS/master/kas.version",
+    "DOWNLOAD": "http://forum.kerbalspaceprogram.com/threads/92514",
+    "CHANGE_LOG_URL": "https://raw.githubusercontent.com/KospY/KAS/master/changelog.md",
+    "GITHUB":
     {
-        "USERNAME":"KospY",
-        "REPOSITORY":"KAS",
-        "ALLOW_PRE_RELEASE":false,
+        "USERNAME": "KospY",
+        "REPOSITORY": "KAS"
     },
-	"VERSION":
-	{
-		"MAJOR":0,
-		"MINOR":5,
-		"PATCH":2,
-		"BUILD":0
-	},
-	"KSP_VERSION":
-	{
-		"MAJOR":1,
-		"MINOR":0,
-		"PATCH":2
-	}
+    "VERSION":
+    {
+        "MAJOR": 0,
+        "MINOR": 5,
+        "PATCH": 2,
+        "BUILD": 0
+    },
+    "KSP_VERSION":
+    {
+        "MAJOR": 1,
+        "MINOR": 0,
+        "PATCH": 2
+    }
 }


### PR DESCRIPTION
The KSP-AVC check will now display "Kerbal Attachment System" as opposed to "KAS", the thread link is now pruned of the unnecessary thread title stuff, removed the "ALLOW_PRE_RELEASE" line as that defaults to false anyways, and regularised the tabs.

On a related note, wouldn't it be easier to set the download URL to https://github.com/KospY/KAS/releases and use that instead of (or in addition to) the forum thread?